### PR TITLE
fix: navbar visibility

### DIFF
--- a/src/components/Avatar/index.jsx
+++ b/src/components/Avatar/index.jsx
@@ -12,8 +12,8 @@ const Avatar = ({ profile }) => (
       <img src={profile.photoURL} alt="User avatar" className="avatar-photo" />
     ) : (
       <span className="avatar-letters">
-        {profile.firstName.charAt(0)}
-        {profile.lastName.charAt(0)}
+        {profile.firstName?.charAt(0)}
+        {profile.lastName?.charAt(0)}
       </span>
     )}
   </div>


### PR DESCRIPTION
navbar is not rendered if first name/last name is missing. this patch
fixes this by not showing letters in avatar for user with a missing
first name/last name